### PR TITLE
Add task queue

### DIFF
--- a/uploader/app.js
+++ b/uploader/app.js
@@ -1,37 +1,26 @@
-express     = require('express')
-multer      = require('multer')
-path        = require('path')
-fork        = require('child_process').fork
-
-upload      = multer({ dest: 'uploaded_aois' })
-app         = express()
-
-// Ensure correct working directory
-process.chdir(__dirname)
+'use strict'
+const express     = require('express')
+const multer      = require('multer')
+const path        = require('path')
+const fork        = require('child_process').fork
+const processAoi  = require('./middleware/process-aoi')
+const upload      = multer({ dest: __dirname + '/../uploaded_aois' })
+const app         = express()
 
 // Use Jade (http://jade-lang.org) for templates
 app.set('view engine', 'jade')
 app.set('views', __dirname + '/views')
 
 // Serve static assets
-app.use(express.static('public'))
+app.use(express.static(__dirname + '/public'))
 
 // Server upload page
 app.get('/', function (req, res) {
   res.render('upload')
 })
 
-process.chdir('../') // return to root dir
-
 // Accept AOI uploads
-app.post('/aois', upload.single('file'), function (req, res, next) {
-  res.header('Content-Type', 'text/plain')
-  res.send('Upload complete, starting subject fetch job')
-
-  // Start job, ensuring correct working directory
-  var script = 'planet-api-before-after-test'
-  var job = fork(script, [req.file.path])
-})
+app.post('/aois', upload.single('file'), processAoi)
 
 // Start the server
 app.listen(3736, function () {

--- a/uploader/lib/create-subject-job.js
+++ b/uploader/lib/create-subject-job.js
@@ -1,0 +1,7 @@
+const SubjectJob = require('../lib/subject-job')
+
+module.exports = function (job, done) {
+    const jobInst = new SubjectJob(job.file, job.username, job.password)
+    jobInst.onFinish(done)
+    return jobInst
+}

--- a/uploader/lib/subject-job.js
+++ b/uploader/lib/subject-job.js
@@ -1,0 +1,32 @@
+'use strict'
+const fork = require('child_process').fork
+
+const SCRIPT = __dirname + '/../../planet-api-before-after-test'
+
+module.exports = class SubjectJob {
+    constructor (file, username, password) {
+        // Store params
+        this.file = file
+        this.username = username
+        this.password = password
+        
+        // Create child process
+        this.job = fork(SCRIPT, [this.file], Object.assign(process.env, {
+            ZOONIVERSE_USERNAME: this.username,
+            ZOONIVERSE_PASSWORD: this.password
+        }))
+        
+        // @todo store output from child process
+        this.output = []
+        
+        // Set up callback
+        this.job.on('close', code => {
+            if (this.done) this.done(code > 0, this.output.join("\n"))
+        })
+    }
+    
+    // Sets the callback for the job
+    onFinish (done) {
+        this.done = done
+    }
+}

--- a/uploader/lib/subject-job.js
+++ b/uploader/lib/subject-job.js
@@ -1,7 +1,8 @@
 'use strict'
+const path = require('path')
 const fork = require('child_process').fork
 
-const SCRIPT = __dirname + '/../../planet-api-before-after-test'
+const SCRIPT = path.join(__dirname, '../../planet-api-before-after-test')
 
 module.exports = class SubjectJob {
     constructor (file, username, password) {
@@ -11,10 +12,13 @@ module.exports = class SubjectJob {
         this.password = password
         
         // Create child process
-        this.job = fork(SCRIPT, [this.file], Object.assign(process.env, {
-            ZOONIVERSE_USERNAME: this.username,
-            ZOONIVERSE_PASSWORD: this.password
-        }))
+        this.job = fork(SCRIPT, [this.file], {
+            env: Object.assign(process.env, {
+                ZOONIVERSE_USERNAME: this.username,
+                ZOONIVERSE_PASSWORD: this.password
+            }),
+            cwd: path.join(__dirname, '../..')
+        })
         
         // @todo store output from child process
         this.output = []

--- a/uploader/middleware/process-aoi.js
+++ b/uploader/middleware/process-aoi.js
@@ -2,7 +2,7 @@
 const async = require('async')
 const createSubjectJob = require('../lib/create-subject-job')
 
-const queue = async.queue(createSubjectJob, 3)
+const queue = async.queue(createSubjectJob, process.env.AOI_JOB_CONCURRENCY || 1)
 
 module.exports = function (req, res, next) {
   // Start job

--- a/uploader/middleware/process-aoi.js
+++ b/uploader/middleware/process-aoi.js
@@ -1,0 +1,19 @@
+'use strict'
+const async = require('async')
+const createSubjectJob = require('../lib/create-subject-job')
+
+const queue = async.queue(createSubjectJob, 3)
+
+module.exports = function (req, res, next) {
+  // Start job
+  const job = {
+    file: req.file.path,
+    username: process.env.ZOONIVERSE_USERNAME,
+    password: process.env.ZOONIVERSE_PASSWORD
+  }
+  queue.push(job)
+
+  // Send confirmation
+  res.header('Content-Type', 'text/plain')
+  res.send('Upload complete, subject fetch job queued')
+}


### PR DESCRIPTION
Enables queuing of the before-after tasks. I imagine we'll only want to run a few in parallel.

@saschaishikawa As mentioned in the last commit, I think `USE_MOSAIC_CACHE` and `AOI_JOB_CONCURRENCY` are more runtime options than env vars; if you agree I can amend them. 