### PR TITLE
- Add message queue via RSMQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ data/nepal*mosaic
 .DS_Store
 uploaded_aois
 npm-debug.log
+supervisord.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /generate-subjects-from-planet-api
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get -y upgrade && \
-    apt-get install --no-install-recommends -y ca-certificates sudo git curl bash-completion vim-tiny imagemagick libimage-exiftool-perl make g++ python
+    apt-get install --no-install-recommends -y ca-certificates sudo git curl bash-completion vim-tiny supervisor imagemagick libimage-exiftool-perl make g++ python
 
 RUN curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
 
@@ -21,9 +21,12 @@ RUN update-locale LANG=en_US.UTF-8
 RUN alias ls='ls --color=auto'
 RUN alias ll='ls -halF'
 
+ADD supervisord.conf /etc/supervisor/supervisord.conf
+
 ADD ./ /generate-subjects-from-planet-api
 
 RUN npm install .
 
 EXPOSE 3736
-CMD ["npm", "start"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]
+# CMD ["echo", "hello there!"]

--- a/README.md
+++ b/README.md
@@ -8,48 +8,12 @@ Clone and `npm install`. A number of environmental variables must be set:
 * to deploy to subjects to your Zooniverse project you'll need to [build a project](https://www.zooniverse.org/lab) and set the variables `ZOONIVERSE_USERNAME` and `ZOONIVERSE_PASSWORD` with your username and password, respectively
 * `AMAZON_ACCESS_KEY_ID` and `AMAZON_SECRET_ACCESS_KEY` an S3 bucket in order to deploy subjects
 
-Run `npm start` to launch the app locally.
+Run `docker-compose up`. The main application container and a redis container will be started. You can then upload KML files at http://localhost:3736.
 
-There are three scripts set up to demonstrate what's currently implemented.
+## Running outside of Docker
+1) Set up a [redis](https://redis.io) server.
+2) Run `REDIS_HOST=your-redis-host.com npm start` (if you need to set a custom port for redis, use `REDIS_PORT`)
 
-### Fetching Mosaics by Area of Interest (AOI)
-Run `npm run-script planet-api-test` on the CLI to access the API and fetch mosaics intersecting with a polygonal AOI inscribing central Kathmandu. This should download two GeoTIF files in the `/data` directory along with corresponding JSON files containing the "Features" hash. This will be useful in the future for retrieving metadata and digging through individual scenes that make up the mosaic. It's also used as a placeholder to append the geo coordinates we'll calculate next.
-
-### Computing Reference Coordinates
-Run `npm run-script geo-coords-test` on the CLI. This will extract the coordinates of the corner and center pixels of one of the GeoTIF files (`data/L15-1509E-1188N.tif`) that were downloaded in the previous section. The resulting coordinates are appended in the `reference_coordinates` hash of its corresponding JSON file.
-
-```
-"reference_coordinates": {
-	"upper_left": {
-		"lat": 27.839074999999998,
-		"lon": 85.25390555555556
-	},
-	"upper_right": {
-		"lat": 27.839074999999998,
-		"lon": 85.42968611111111
-	},
-	"bottom_right": {
-		"lat": 27.68352777777778,
-		"lon": 85.42968611111111
-	},
-	"bottom_left": {
-		"lat": 27.68352777777778,
-		"lon": 85.25390555555556
-	},
-	"center": {
-		"lat": 27.761330555555556,
-		"lon": 85.34179722222221
-	}
-}
-```
-
-### Generating Tiles
-Run `npm run-script tilize-images` on the CLI. This will split one of the downloaded mosaic GeoTIFs (`data/L15-1509E-1188N.tif`) into tiles 480px square, with 160px overlap between tiles and write a subject set file (`data/manifest.csv`) ready to upload to Panoptes. For customisation options, run `node tilize-images`.
-
-TO DO: Interpolate geo coords of individual tiles and generate metadata. Creating subjects and loading into Panoptes follows.
-
-### Tying it all together
-Run `npm run-script planet-api-before-after-test` on the CLI to fetch before/after-quake Nepal mosaics, tile them, interpolate coords of individual tiles and write a subject manifest. Images in the manifest will be uploaded to the S3 bucket and Zooniverse subjects will be generated and deployed. By default this won't re-fetch already downloaded mosaics; to override this behaviour run with `USE_MOSAIC_CACHE=0`
-
-Alternatively, start the KML uploader app with either `PLANET_API_KEY=your_key npm run-script uploader` or `PLANET_API_KEY=your_key docker-compose up` 
+## Tests
+We should write some of these.
 

--- a/app/lib/create-subject-job.js
+++ b/app/lib/create-subject-job.js
@@ -1,0 +1,7 @@
+const SubjectJob = require('../lib/subject-job')
+
+module.exports = function (job, done) {
+    const jobInst = new SubjectJob(job.file)
+    jobInst.onFinish(done)
+    return jobInst
+}

--- a/app/lib/queue.js
+++ b/app/lib/queue.js
@@ -1,0 +1,23 @@
+const Rsmq = require('rsmq')
+
+const QUEUE_NAME = 'zooniverse_prn'
+const rsmq = new Rsmq({
+  host: process.env.REDIS_HOST || 'redis',
+  port: process.env.REDIS_PORT || 6379,
+  ns: 'rsmq'
+})
+rsmq.createQueue({ qname: QUEUE_NAME }, function (err, resp) {
+  if (resp === 1) {
+    console.log("queue created")
+  }
+})
+
+module.exports = {
+  push: function (message) {
+    rsmq.sendMessage({ qname: QUEUE_NAME, message: message }, function (err, resp) {
+      if (resp) {
+        console.log("Message sent. ID:", resp);
+      }
+    });
+  }
+}

--- a/app/lib/subject-job.js
+++ b/app/lib/subject-job.js
@@ -1,0 +1,36 @@
+'use strict'
+const path = require('path')
+const fork = require('child_process').fork
+
+const SCRIPT = path.join(__dirname, '../../planet-api-before-after-test')
+
+module.exports = class SubjectJob {
+    constructor (file, username, password) {
+        // Store params
+        this.file = file
+        this.username = username
+        this.password = password
+        
+        // Create child process
+        this.job = fork(SCRIPT, [this.file], {
+            env: Object.assign(process.env, {
+                ZOONIVERSE_USERNAME: this.username,
+                ZOONIVERSE_PASSWORD: this.password
+            }),
+            cwd: path.join(__dirname, '../..')
+        })
+        
+        // @todo store output from child process
+        this.output = []
+        
+        // Set up callback
+        this.job.on('close', code => {
+            if (this.done) this.done(code > 0, this.output.join("\n"))
+        })
+    }
+    
+    // Sets the callback for the job
+    onFinish (done) {
+        this.done = done
+    }
+}

--- a/app/main.js
+++ b/app/main.js
@@ -1,3 +1,4 @@
+processAoi  = require('./middleware/process-aoi')
 express     = require('express')
 multer      = require('multer')
 path        = require('path')
@@ -24,16 +25,7 @@ app.get('/', function (req, res) {
 process.chdir('../') // return to root dir
 
 // Accept AOI uploads
-app.post('/aois', upload.single('file'), function (req, res, next) {
-  res.header('Content-Type', 'text/plain')
-  res.send('Upload complete, starting subject fetch job')
-
-  // Start job, ensuring correct working directory
-  console.log('CWD: ', process.cwd() );
-  console.log('Loading AOI ', req.file.path);
-  var script = 'planet-api-before-after-test'
-  var job = fork(script, [req.file.path])
-})
+app.post('/aois', upload.single('file'), processAoi)
 
 // Start the server
 app.listen(3736, function () {

--- a/app/middleware/process-aoi.js
+++ b/app/middleware/process-aoi.js
@@ -1,0 +1,13 @@
+'use strict'
+const path = require('path')
+const queue = require('../lib/queue')
+const UPLOAD_PATH = __dirname + '/../../uploaded_aois'
+
+module.exports = function (req, res, next) {
+  // Send job to queue
+  queue.push(path.join(UPLOAD_PATH, req.file.filename))
+
+  // Send confirmation
+  res.header('Content-Type', 'text/plain')
+  res.send('Upload complete, subject fetch job queued')
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,23 @@
-planetsubjects:
-  dockerfile: Dockerfile
-  build: ./
-  volumes:
-    - ./:/generate-subjects-from-planet-api
-  ports:
-    - "3736:3736"
-  environment:
-    - "NODE_ENV=development"
-    - "PLANET_API_KEY"
-    - "AMAZON_ACCESS_KEY_ID"
-    - "AMAZON_SECRET_ACCESS_KEY"
-    - "ZOONIVERSE_USERNAME"
-    - "ZOONIVERSE_PASSWORD"
+version: '2'
+
+services:
+  redis:
+    image: redis
+    command: redis-server --appendonly yes
+    ports:
+      - "6379:6379"
+
+  planetsubjects:
+    build: ./
+    volumes:
+      - ./:/generate-subjects-from-planet-api
+    ports:
+      - "3736:3736"
+    environment:
+      - "NODE_ENV=development"
+      - "PLANET_API_KEY"
+      - "AMAZON_ACCESS_KEY_ID"
+      - "AMAZON_SECRET_ACCESS_KEY"
+      - "ZOONIVERSE_USERNAME"
+      - "ZOONIVERSE_PASSWORD"
+

--- a/generator/main.js
+++ b/generator/main.js
@@ -1,0 +1,48 @@
+'use strict'
+const path             = require('path')
+const fork             = require('child_process').fork
+const RSMQWorker       = require('rsmq-worker')
+
+const LOG_TAG = 'prn_factory'
+const GENERATOR_SCRIPT = path.join(__dirname, '../planet-api-before-after-test.js')
+const QUEUE_NAME = 'zooniverse_prn'
+
+// Scoped logging
+function log () {
+  let msgs = ['[' + LOG_TAG + ']']
+  msgs = msgs.concat(Array.from(arguments))
+  console.log.apply(this, msgs)
+}
+
+// Create worker
+const worker = new RSMQWorker(QUEUE_NAME, {
+  maxReceiveCount: 1,
+  host: process.env.REDIS_HOST || 'redis',
+  port: process.env.REDIS_PORT || 6379,
+  timeout: 0 // Wait indefinitely for jobs to finish before grabbing another
+})
+
+// Listen for jobs
+worker.on( "message", function(filename, next) {
+  log('received message', filename, 'spawning', GENERATOR_SCRIPT)
+  const job = fork(GENERATOR_SCRIPT, [filename])
+  job.on('close', function (code) {
+    log('Job for', filename, 'finished with code', code)
+    next()
+  })
+})
+
+// Handle errors/lifecycle
+worker.on('error', function(err, msg) {
+    log("ERROR", err, msg.id)
+})
+worker.on('exceeded', function(msg) {
+    log("EXCEEDED", msg.id)
+})
+worker.on('timeout', function(msg) {
+    log("TIMEOUT", msg.id, msg.rc)
+})
+
+// Kickoff
+worker.start()
+log('Listening for jobs in queue', QUEUE_NAME)

--- a/modules/planet-api.js
+++ b/modules/planet-api.js
@@ -73,7 +73,7 @@ function processFeatures(features, label, callback){
     var meta_dest = 'data/' + basename + '_' + label + '.json'
 
     // prepare array of function calls
-    task_list.push( async.apply( downloadFile, url, dest ) )
+    task_list.push( async.apply( downloadFile, { url: url, dest: dest } ) )
 
     /* Write Metadata to JSON */
     fs.writeFile(meta_dest, jsonFormat(features[i]), function(err){
@@ -91,8 +91,10 @@ function processFeatures(features, label, callback){
 }
 
 /* Downloads a file at url to dest */
-function downloadFile(url, dest, callback){
-  if (process.env.USE_MOSAIC_CACHE && fs.existsSync(dest)) {
+function downloadFile(options, callback){
+  const url = options.url
+  const dest = options.dest
+  if (!options.skip_cache && fs.existsSync(dest)) {
     console.log('  Using cached mosaic: ' + dest);
     callback(null, dest)
   } else {

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
     "planet-api-test": "node planet-api-test.js",
     "geo-coords-test": "node geo-coords-test.js data/L15-1509E-1188N.tif",
     "tilize-test": "node tilize-images.js data/L15-1509E-1188N.tif",
-    "planet-api-before-after-test": "USE_MOSAIC_CACHE=1 node planet-api-before-after-test.js",
-    "uploader": "USE_MOSAIC_CACHE=1 nodemon app/main.js",
+    "planet-api-before-after-test": "node planet-api-before-after-test.js",
+    "uploader": "nodemon app/main.js",
     "watch": "watchify app/javascripts/index.js -o app/public/app.js -v",
     "build": "browserify app/javascripts/index.js -o app/public/app.js",
-    "start": "npm run watch & USE_MOSAIC_CACHE=1 nodemon --watch app app/main.js"
+    "producer": "npm run watch & nodemon --watch app app/main.js",
+    "consumer": "NODE_ENV=staging nodemon --watch generator generator/main.js",
+    "start": "npm run producer & npm run consumer"
   },
   "dependencies": {
     "async": "~1.5.2",
@@ -29,6 +31,8 @@
     "nodemon": "^1.5.0-alpha4",
     "panoptes-client": "^2.0.1",
     "request": "~2.67.0",
+    "rsmq": "^0.4.0",
+    "rsmq-worker": "^0.3.8",
     "togeojson": "^0.13.0",
     "watchify": "^3.7.0",
     "xmlhttprequest-cookie": "^0.9.4",

--- a/planet-api-before-after-test.js
+++ b/planet-api-before-after-test.js
@@ -57,6 +57,7 @@ planetAPI.fetchBeforeAndAfterMosaicFromAOI( before_url, after_url, bounds,
       }
       console.log('Tilizing images...');
       var start_time = Date.now()
+
       async.series( task_list, function(error, result) {
         var elapsed_time = parseFloat( (Date.now()-start_time) / 60 / 1000).toFixed(2)
         console.log('Tilizing complete (' + elapsed_time + ' minutes)');

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,20 @@
+[supervisord]
+nodaemon=true
+
+[program:prn_producer]
+user=root
+command=npm run producer
+directory=/generate-subjects-from-planet-api
+autorestart=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+
+[program:prn_consumer]
+user=root
+command=npm run consumer
+directory=/generate-subjects-from-planet-api
+autorestart=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true


### PR DESCRIPTION
- Separate job producer and consumer
- Remove mosaic cache env var, add skip cache option on downloadFile method (currently not exposed)
- Trim old test scripts from readme (we should implement tests for the various moving parts instead)

The advantage of using a message queue (in this case over Redis) with a separate producer and consumer (instead of having the uploader app directly spawn child workers) is that the job queue will be persisted even if the uploader crashed, and can easily be resumed later. Redis also offers various backup functionality which is nice to have.

This is moving towards the uploader app becoming the "dashboard" for the PRN process - once we've got sessions with oauth sorted, we can let users (or at least admins) monitor their running jobs from the interface (I realise this might have to be a later addition).

The separation of concerns should also help us with keeping the code tight.

I've also trimmed the README to just show the running instructions for the main app. We should add some tests for the various moving parts. 

Oh, and I got rid of `USE_MOSAIC_CACHE` as an env var and added `skip_cache` as [an option](https://github.com/zooniverse/generate-subjects-from-planet-api/blob/message_queue/modules/planet-api.js#L94-L97) on `downloadFile`. It's not settable via the command line yet, because I don't think we need it at the moment (and we don't currently have any other runtime options, so didn't want to add unnecessary parsing with yargs). If we decide we want to be able to disable the cache (because, e.g. the mosaics change over time) then we can always add it as a runtime options.

Note: the message queue I chose is [rsmq](https://github.com/smrchy/rsmq) but we could easily swap it out for anything else that runs on Redis (or we could ditch Redis altogether). 